### PR TITLE
(569a) Restore E2E tests

### DIFF
--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -24,7 +24,7 @@ test('has a title and a list of accredited programmes', async ({ page }) => {
     'Thinking Skills Programme (TSP)',
   ])
 
-  await page.locator('div[role="list"] .govuk-grid-row:first-child a').click()
+  await page.locator('div[role="list"] > .govuk-grid-row:first-child a').click()
   await expect(page.locator('h1')).toHaveText('Becoming New Me Plus (BNM+)')
   await expect(page.locator('.govuk-table__cell:first-child')).toHaveText([
     'Bure (HMP)',

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -4,15 +4,45 @@ test('has a title and a list of accredited programmes', async ({ page }) => {
   await page.goto('/programmes')
   await expect(page.locator('h1')).toHaveText('List of accredited programmes')
   const courseLinks = await page.locator('div[role="list"] a')
-  expect(courseLinks).toHaveText(['Lime Course', 'Azure Course', 'Violet Course'])
+  expect(courseLinks).toHaveText([
+    'Becoming New Me Plus (BNM+)',
+    'Becoming New Me Plus (BNM+)',
+    'Becoming New Me Plus (BNM+)',
+    'Building Better Relationships (BBR)',
+    'Healthy Identity Intervention (HII)',
+    'Healthy Sex Programme (HSP)',
+    'Horizon',
+    'Identity Matters (IM)',
+    'Identity Matters (IM)',
+    'Kaizen',
+    'Kaizen',
+    'Kaizen',
+    'Living as New Me (LNM)',
+    'New Me Strengths (NMS)',
+    'New Me Strengths (NMS)',
+    'New Me Strengths (NMS)',
+    'Thinking Skills Programme (TSP)',
+  ])
 
   await page.locator('div[role="list"] .govuk-grid-row:first-child a').click()
-  await expect(page.locator('h1')).toHaveText('Lime Course')
-  await expect(page.locator('.govuk-table__cell:first-child')).toHaveText(['Brixton (HMP)', 'Moorland (HMP & YOI)'])
+  await expect(page.locator('h1')).toHaveText('Becoming New Me Plus (BNM+)')
+  await expect(page.locator('.govuk-table__cell:first-child')).toHaveText([
+    'Bure (HMP)',
+    'Hull (HMP & YOI)',
+    'Isle Of Wight (HMP & YOI)',
+    'Swinfen Hall (HMP & YOI)',
+    'Usk (HMP)',
+    'Wakefield (HMP)',
+    'Whatton (HMP)',
+    'Wymott (HMP & YOI)',
+  ])
 
   await page.locator('.govuk-table__row:first-child > .govuk-table__cell:nth-child(4) > a').click()
-  await expect(page.locator('h1')).toHaveText('Lime Course')
-  await expect(page.locator('h2')).toHaveText('Brixton (HMP)')
+  await expect(page.locator('h1')).toHaveText('Becoming New Me Plus (BNM+)')
+  await expect(page.locator('h2')).toHaveText('Bure (HMP)')
   const mailToLink = page.locator('.govuk-summary-list__value .govuk-link')
-  await expect(mailToLink).toHaveAttribute('href', 'mailto:nobody-bxi@digital.justice.gov.uk')
+  await expect(mailToLink).toHaveAttribute(
+    'href',
+    'mailto:obpbure@justice.gov.uk?subject=Accredited%20programme%20referral%20-%20Bure%20(HMP)%20-%20Becoming%20New%20Me%20Plus',
+  )
 })


### PR DESCRIPTION
We disabled the E2E tests on the UI in https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/pull/98. We want to re-enable them, but first we need to update the tests to match the current dev data. This does that