### PR TITLE
Add test to verify AppInsights cookies are set

### DIFF
--- a/tests/applicationInsights.spec.ts
+++ b/tests/applicationInsights.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test'
+
+test('sets the Application Insights cookies', async ({ page }) => {
+  await page.goto('/')
+
+  let cookies = await page.context().cookies()
+  expect(cookies.find(c => c.name === 'ai_user').value).not.toBeUndefined()
+
+  await page.goto('/programmes')
+
+  cookies = await page.context().cookies()
+  expect(cookies.find(c => c.name === 'ai_session').value).not.toBeUndefined()
+})


### PR DESCRIPTION
This checks that the `ai_user` and `ai_session` cookies are set when navigating around the service to ensure the Application Insights script tag is working as expected.