### PR TITLE
(704b) Test creation of referral

### DIFF
--- a/tests/refer.spec.ts
+++ b/tests/refer.spec.ts
@@ -8,7 +8,7 @@ test('allows users to make a referral', async ({ page }) => {
 
   await searchesForAPrisoner(page)
 
-  await asksForPrisonerConfirmation(page)
+  await createsAReferral(page)
 
   // further steps to follow
 })
@@ -29,12 +29,13 @@ const searchesForAPrisoner = async (page: Page): Promise<void> => {
   await expect(page.locator('h1')).toHaveText("Enter the person's identifier")
   await page.getByLabel('Enter identifier').fill(prisonNumber)
   await page.getByRole('button', { name: 'Continue' }).click()
-}
-
-const asksForPrisonerConfirmation = async (page: Page): Promise<void> => {
   await expect(page.locator('h1')).toHaveText("Confirm Andrew Smith's details")
   await expect(page.locator('.govuk-summary-list__row:nth-child(2) .govuk-summary-list__value')).toHaveText(
     prisonNumber,
   )
-  await expect(page.getByRole('button', { name: 'Continue' })).toHaveCount(1)
+}
+
+const createsAReferral = async (page: Page): Promise<void> => {
+  await page.getByRole('button', { name: 'Continue' }).click()
+  await expect(page.locator('h1')).toHaveText('Make a referral')
 }


### PR DESCRIPTION
... and redirection to the tasklist page. Currently we have two `h1`s that have the same content: the referral start page and the tasklist page. We might want to review whether we're happy that these assertions are enough, although the pages are reasonably far apart, so it's unlikely that we'd accidentally be on the wrong one