### PR TITLE
(857b) Update referral reason to additional information

### DIFF
--- a/tests/refer.spec.ts
+++ b/tests/refer.spec.ts
@@ -100,10 +100,10 @@ const confirmsOasys = async (page: Page): Promise<void> => {
 
 const entersAdditionalInformation = async (page: Page): Promise<void> => {
   await page.getByRole('link', { name: 'Add additional information' }).click()
-  await expect(page.locator('h1')).toHaveText('Add reason for referral and any additional information')
-  await page.getByLabel('Add reason for referral and any additional information').fill('This is a test reason.')
+  await expect(page.locator('h1')).toHaveText('Add additional information')
+  await page.getByLabel('Add additional information').fill('Brussel sprouts could be more popular.')
   await page.getByRole('button', { name: 'Save and continue' }).click()
-  await expect(page.getByTestId('reason-tag')).toHaveText('completed')
+  await expect(page.getByTestId('additional-information-tag')).toHaveText('completed')
 }
 
 const showsCheckAnswersBeforeSubmitting = async (page: Page): Promise<void> => {


### PR DESCRIPTION
Ther's a CircleCI check failing here, which is odd, because we didn't have Circle CI configured on this repo. Looks like Approved Premises have had similar in their last E2E PR, but they merged it anyway. I think we can ignore them for now (since they're just telling us to delete the example test and write real ones) and figure out why they're running separately