### PR TITLE
Use dxw Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["github>dxw/renovate-config"]
 }


### PR DESCRIPTION
Use the dxw default Renovate config, which is meant for client projects and automatically merges patch dependency updates. Since this repository is not deployed anywhere, and only used for CI checks, we should be confident in merging patch updates