### PR TITLE
Disable Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2.1
+
+orbs:
+  hmpps: ministryofjustice/hmpps@7.2.1
+
+jobs:
+  placeholder-job:
+    executor:
+      name: hmpps/node
+      tag: 20.9-browsers
+    steps:
+      - checkout
+      - run: |
+          # echo Hello, World!
+
+workflows:
+  placeholder-workflow:
+    jobs:
+      - placeholder-job


### PR DESCRIPTION
This is an attempt to stop CircleCI breaking CI checks on the repo by providing a placeholder config file

There is an option to "Stop building" [here](https://app.circleci.com/settings/project/github/ministryofjustice/hmpps-accredited-programmes-e2e) which might do the job, but this is an alternative hack if that's not suitable