### PR TITLE
Make index row selector robust

### DIFF
--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -6,7 +6,11 @@ test('allows users to find a programme and offering', async ({ page }) => {
 
   await showsListOfProgrammes(page)
 
-  await page.locator('div[role="list"] > .govuk-grid-row:first-child a').click()
+  const rowIndexOfBecomingNewMePlusSexualOffence = await getRowIndexOfBecomingNewMePlusSexualOffence(page)
+
+  await page
+    .locator(`div[role="list"] > .govuk-grid-row:nth-child(${rowIndexOfBecomingNewMePlusSexualOffence + 1}) a`)
+    .click()
 
   await showsListOfOfferings(page)
 
@@ -35,6 +39,19 @@ const showsListOfProgrammes = async (page: Page): Promise<void> => {
     'New Me Strengths (NMS)',
     'Thinking Skills Programme (TSP)',
   ])
+}
+
+const getRowIndexOfBecomingNewMePlusSexualOffence = async (page: Page): Promise<number> => {
+  return page.evaluate(() => {
+    const rows = Array.from(document.querySelectorAll('.govuk-grid-row'))
+
+    return rows.findIndex(row => {
+      return (
+        row.querySelector('.govuk-link').textContent.trim() === 'Becoming New Me Plus (BNM+)' &&
+        row.querySelector('.govuk-tag').textContent.trim() === 'Sexual offence'
+      )
+    })
+  })
 }
 
 const showsListOfOfferings = async (page: Page): Promise<void> => {


### PR DESCRIPTION
On the list of programmes, we were clicking on the link in the first row to move to the programme page. After a dev data refresh, the order of the programme list changed (we only sort by name in the UI, and names are not unique). This broke the tests, since they were now navigating to an unexpected programme

This ensures we're always navigating to the programme we expect by searching for the index of the correct row, then interpolating that index into the appropriate selector