### PR TITLE
Update status tag text

### DIFF
--- a/tests/refer.spec.ts
+++ b/tests/refer.spec.ts
@@ -95,7 +95,7 @@ const confirmsOasys = async (page: Page): Promise<void> => {
   await expect(page.locator('h1')).toHaveText('Confirm the OASys information')
   await page.getByLabel('I confirm that the OASys information is up to date.').check()
   await page.getByRole('button', { name: 'Save and continue' }).click()
-  await expect(page.getByTestId('confirm-oasys-tag')).toHaveText('completed')
+  await expect(page.getByTestId('confirm-oasys-tag')).toHaveText('Completed')
 }
 
 const entersAdditionalInformation = async (page: Page): Promise<void> => {
@@ -103,7 +103,7 @@ const entersAdditionalInformation = async (page: Page): Promise<void> => {
   await expect(page.locator('h1')).toHaveText('Add additional information')
   await page.getByLabel('Add additional information').fill('Brussel sprouts could be more popular.')
   await page.getByRole('button', { name: 'Save and continue' }).click()
-  await expect(page.getByTestId('additional-information-tag')).toHaveText('completed')
+  await expect(page.getByTestId('additional-information-tag')).toHaveText('Completed')
 }
 
 const showsCheckAnswersBeforeSubmitting = async (page: Page): Promise<void> => {


### PR DESCRIPTION
After upgrading the UI to use `govuk-frontend@5`, status tags are now in sentence case