### PR TITLE
1421 - fix e2e tests - update course names

### DIFF
--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -23,20 +23,22 @@ const showsListOfProgrammes = async (page: Page): Promise<void> => {
   await expect(page.locator('h1')).toHaveText('List of accredited programmes')
   const courseLinks = page.locator('div[role="list"] a')
   expect(courseLinks).toHaveText([
-    'Becoming New Me Plus (BNM+)',
-    'Becoming New Me Plus (BNM+)',
-    'Becoming New Me Plus (BNM+)',
+    'Becoming New Me Plus: general violence offence (BNM+)',
+    'Becoming New Me Plus: intimate partner violence offence (BNM+)',
+    'Becoming New Me Plus: sexual offence (BNM+)',
     'Building Better Relationships (BBR)',
     'Healthy Identity Intervention (HII)',
     'Healthy Sex Programme (HSP)',
     'Horizon',
     'Identity Matters (IM)',
-    'Identity Matters (IM)',
-    'Kaizen',
-    'Kaizen',
-    'Kaizen',
+    'Kaizen: general violence offence',
+    'Kaizen: intimate partner violence offence',
+    'Kaizen: sexual offence',
     'Living as New Me (LNM)',
-    'New Me Strengths (NMS)',
+    'New Me MOT',
+    'New Me Strengths: general violence offence (NMS)',
+    'New Me Strengths: intimate partner violence offence (NMS)',
+    'New Me Strengths: sexual offence (NMS)',
     'Thinking Skills Programme (TSP)',
   ])
 }
@@ -47,7 +49,7 @@ const getRowIndexOfBecomingNewMePlusSexualOffence = async (page: Page): Promise<
 
     return rows.findIndex(row => {
       return (
-        row.querySelector('.govuk-link')?.textContent.trim() === 'Becoming New Me Plus (BNM+)' &&
+        row.querySelector('.govuk-link')?.textContent.trim() === 'Becoming New Me Plus: sexual offence (BNM+)' &&
         row.querySelector('.govuk-tag')?.textContent.trim() === 'Sexual offence'
       )
     })
@@ -55,7 +57,7 @@ const getRowIndexOfBecomingNewMePlusSexualOffence = async (page: Page): Promise<
 }
 
 const showsListOfOfferings = async (page: Page): Promise<void> => {
-  await expect(page.locator('h1')).toHaveText('Becoming New Me Plus (BNM+)')
+  await expect(page.locator('h1')).toHaveText('Becoming New Me Plus: sexual offence (BNM+)')
   const prisonListItems = page.locator('.govuk-table__cell:first-child')
   await expect(prisonListItems).toHaveText([
     'Bure (HMP)',
@@ -71,12 +73,12 @@ const showsListOfOfferings = async (page: Page): Promise<void> => {
 }
 
 const showsSingleOffering = async (page: Page): Promise<void> => {
-  await expect(page.locator('h1')).toHaveText('Becoming New Me Plus (BNM+)')
+  await expect(page.locator('h1')).toHaveText('Becoming New Me Plus: sexual offence (BNM+)')
   await expect(page.locator('h2.govuk-heading-m')).toHaveText('Whatton (HMP)')
   const mailToLink = page.locator('.govuk-summary-list__value .govuk-link')
   await expect(mailToLink).toHaveAttribute(
     'href',
-    'mailto:whattonprogrammes@justice.gov.uk?subject=Accredited%20programme%20referral%20-%20Whatton%20(HMP)%20-%20Becoming%20New%20Me%20Plus',
+    'mailto:whattonprogrammes@justice.gov.uk?subject=Accredited%20programme%20referral%20-%20Whatton%20(HMP)%20-%20Becoming%20New%20Me%20Plus%3A%20sexual%20offence',
   )
   await hasMakeAReferralButtonLink(page)
 }

--- a/tests/refer.spec.ts
+++ b/tests/refer.spec.ts
@@ -31,7 +31,7 @@ const prisonNumber = 'A8731DY'
 const startsAReferral = async (page: Page): Promise<void> => {
   await expect(page.locator('h1')).toHaveText('Make a referral')
   await expect(page.locator('h2.govuk-heading-m:first-of-type')).toHaveText(
-    'Whatton (HMP) | Becoming New Me Plus (BNM+)',
+    'Whatton (HMP) | Becoming New Me Plus: sexual offence (BNM+)',
   )
   const startButton = page.getByRole('button', { name: 'Start now' })
   await expect(startButton).toHaveAttribute('href', `${offeringReferralPathBase}/new`)


### PR DESCRIPTION

We updated course name, description and prerequisite as part of 1421, this has caused the e2e tests to fail.
Updating course name in this PR to fix the e2e tests