### PR TITLE
Use different offerings for refer and assess tests

### DIFF
--- a/fixtures/assess.ts
+++ b/fixtures/assess.ts
@@ -6,7 +6,10 @@ export default class Assess {
 
   private readonly submitButton: Locator
 
-  constructor(public readonly page: Page) {
+  constructor(
+    public readonly page: Page,
+    public readonly offeringName: string,
+  ) {
     this.continueButton = this.page.getByRole('button', { name: 'Continue' })
     this.submitButton = this.page.getByRole('button', { name: 'Submit' })
   }
@@ -58,7 +61,7 @@ export default class Assess {
 
   async viewStatusHistoryPage(referralId: string) {
     await this.page.goto(`/assess/referrals/${referralId}/status-history`)
-    await expect(this.page.locator('h1')).toHaveText('Referral to Becoming New Me Plus: sexual offence')
+    await expect(this.page.locator('h1')).toHaveText(`Referral to ${this.offeringName}`)
   }
 
   private async assertStatusHistoryTag(tag: string) {

--- a/fixtures/refer.ts
+++ b/fixtures/refer.ts
@@ -8,8 +8,15 @@ export default class Refer {
 
   private readonly referStartPath: string
 
-  constructor(public readonly page: Page) {
-    this.offeringReferralPathBase = '/find/offerings/72820fe9-ad4a-4d1a-b730-ded300075749/referrals'
+  constructor(
+    public readonly page: Page,
+    public readonly offeringId: string,
+    public readonly offeringLocation: string,
+    public readonly offeringName: string,
+  ) {
+    this.offeringReferralPathBase = `/find/offerings/${offeringId}/referrals`
+    this.offeringLocation = offeringLocation
+    this.offeringName = offeringName
     this.prisonNumber = 'A8731DY'
     this.referStartPath = `${this.offeringReferralPathBase}/start`
   }
@@ -140,7 +147,7 @@ export default class Refer {
     await this.page.goto(this.referStartPath)
     await expect(this.page.locator('h1')).toHaveText('Make a referral')
     await expect(this.page.locator('h2.govuk-heading-m:first-of-type')).toHaveText(
-      'Whatton (HMP) | Becoming New Me Plus: sexual offence',
+      `${this.offeringLocation} | ${this.offeringName}`,
     )
     const startButton = this.page.getByRole('button', { name: 'Start now' })
     await expect(startButton).toHaveAttribute('href', `${this.offeringReferralPathBase}/new`)
@@ -149,7 +156,7 @@ export default class Refer {
 
   async viewStatusHistoryPage(referralId: string) {
     await this.page.goto(`/refer/referrals/${referralId}/status-history`)
-    await expect(this.page.locator('h1')).toHaveText('Referral to Becoming New Me Plus: sexual offence')
+    await expect(this.page.locator('h1')).toHaveText(`Referral to ${this.offeringName}`)
   }
 
   async withdrawReferral() {

--- a/tests/assess.spec.ts
+++ b/tests/assess.spec.ts
@@ -5,8 +5,12 @@ import Refer from '../fixtures/refer'
 
 test.use({ storageState: 'playwright/.auth/ptUser.json' })
 
+const offeringId = '1f9441c1-4fc0-4127-a2ef-88be481fba1c'
+const offeringLocation = 'Whatton (HMP)'
+const offeringName = 'Horizon'
+
 test('allows an assess user to update the status of a referral', async ({ page }) => {
-  const refer = new Refer(page)
+  const refer = new Refer(page, offeringId, offeringLocation, offeringName)
 
   await refer.start()
 
@@ -30,7 +34,7 @@ test('allows an assess user to update the status of a referral', async ({ page }
 
   const referralId = page.url().split('/')[6]
 
-  const assess = new Assess(page)
+  const assess = new Assess(page, offeringName)
 
   await assess.viewStatusHistoryPage(referralId)
 

--- a/tests/refer.spec.ts
+++ b/tests/refer.spec.ts
@@ -4,8 +4,12 @@ import Refer from '../fixtures/refer'
 
 test.use({ storageState: 'playwright/.auth/referrerUser.json' })
 
+const offeringId = '72820fe9-ad4a-4d1a-b730-ded300075749'
+const offeringLocation = 'Whatton (HMP)'
+const offeringName = 'Becoming New Me Plus: sexual offence'
+
 test('allows users to create and delete a draft referral', async ({ page }) => {
-  const refer = new Refer(page)
+  const refer = new Refer(page, offeringId, offeringLocation, offeringName)
 
   await refer.start()
 
@@ -17,7 +21,7 @@ test('allows users to create and delete a draft referral', async ({ page }) => {
 })
 
 test('allows users to submit a referral, put it on hold, remove it from hold and withdraw it', async ({ page }) => {
-  const refer = new Refer(page)
+  const refer = new Refer(page, offeringId, offeringLocation, offeringName)
 
   await refer.start()
 


### PR DESCRIPTION
Because tests in different files run in parralel there was a race condition that was triggering the duplicate referral journey.