### PR TITLE
Do not run tests in parallel

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests',
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,


### PR DESCRIPTION
Set [fullParallel](https://playwright.dev/docs/api/class-testconfig#test-config-fully-parallel) to false.

Hoping this solves the intermittent e2e test failures.