### PR TITLE
Added permissions: { contents: read } to both lint.yml and playwright…

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   HMPPS_AUTH_USERNAME: ${{ secrets.HMPPS_AUTH_USERNAME }}
   HMPPS_AUTH_PASSWORD: ${{ secrets.HMPPS_AUTH_PASSWORD }}


### PR DESCRIPTION
….yml. This ensures the GITHUB_TOKEN in each workflow has only the minimum permissions needed — read-only access to repository contents.